### PR TITLE
ci: give the test job more memory headroom

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,10 @@ jobs:
     working_directory: ~/norimaki
     docker:
       - image: cimg/android:2026.02.1
+    resource_class: large
     environment:
       JVM_OPTS: -Xmx3200m
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2
     steps:
       - checkout
       - *restore_cache


### PR DESCRIPTION
The `test` job runs on the default medium resource class (4GB) with `JVM_OPTS: -Xmx3200m`, leaving almost nothing for the Kotlin compile daemon and the test JVM alongside the Gradle daemon.

On #464 (gradle-wrapper 9.7.0 -> 9.7.1) this tips over and the job fails during `:app:testDebugUnitTest`:

```
FAILURE: Build failed with an exception.
* What went wrong:
Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)
> Task :app:testDebugUnitTest
```

Reproduced on two separate runs of the same commit ([#1925](https://circleci.com/gh/circleci-tools/Norimaki/1925), [#1931](https://circleci.com/gh/circleci-tools/Norimaki/1931)), so this is not a flake.

Applies the same settings the `deploy` job already uses: `resource_class: large` plus `GRADLE_OPTS` disabling the daemon and capping workers.

Unblocks #464.